### PR TITLE
Fix invalid rules in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,24 +1,27 @@
-# Default behaviour
-*               text=crlf
-
 # All text files are CRLF
-*.txt		    text eol=crlf
-*.h 		    text eol=crlf
-*.c 		    text eol=crlf
-*.cpp 		    text eol=crlf
-*.hpp 		    text eol=crlf
-*.py 		    text eol=crlf
-*.json 		    text eol=crlf
-*.md 		    text eol=crlf
-*.puml 		    text eol=crlf
-*.plantuml 		text eol=crlf
-*.ini 		    text eol=crlf
-*.bat 		    text eol=crlf
-*.yml 		    text eol=crlf
-*.toml 		    text eol=crlf
-*.cfg 		    text eol=crlf
+*.bat         text eol=crlf
+*.c           text eol=crlf
+*.cfg         text eol=crlf
+*.cpp         text eol=crlf
+*.h           text eol=crlf
+*.hpp         text eol=crlf
+*.ini         text eol=crlf
+*.json        text eol=crlf
+*.md          text eol=crlf
+*.plantuml    text eol=crlf
+*.puml        text eol=crlf
+*.py          text eol=crlf
+*.toml        text eol=crlf
+*.txt         text eol=crlf
+*.yaml        text eol=crlf
+*.yml         text eol=crlf
+
+# Linux shell scripts should be LF
+*.bash        text eol=lf
+*.sh          text eol=lf
+*.zsh         text eol=lf
 
 # Images should be treated as binary
-*.png           binary
-*.jpg           binary
-*.jepg          binary
+*.jpeg        binary
+*.jpg         binary
+*.png         binary


### PR DESCRIPTION
Correct invalid rules, add Linux script rules, and fix mixed tab/spaces. Additionally, include support for .yaml files and correct the handling of .jpeg images.